### PR TITLE
Add custom domain support with Route 53

### DIFF
--- a/terraform/certificate.tf
+++ b/terraform/certificate.tf
@@ -1,7 +1,47 @@
-# Simple approach: Use existing certificate
-# This avoids the for_each dependency issue
+# Certificate with automatic Route 53 validation
+resource "aws_acm_certificate" "app" {
+  domain_name       = "snipethedip.com"
+  subject_alternative_names = ["*.snipethedip.com"]
+  validation_method = "DNS"
 
-# Use your existing certificate
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+# Automatic validation records
+resource "aws_route53_record" "app_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.app.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.main.zone_id
+}
+
+resource "aws_acm_certificate_validation" "app" {
+  certificate_arn         = aws_acm_certificate.app.arn
+  validation_record_fqdns = [for record in aws_route53_record.app_validation : record.fqdn]
+
+  timeouts {
+    create = "10m"
+  }
+}
+
+# Use the terraform-managed certificate
 locals {
-  certificate_arn = "arn:aws:acm:us-west-2:106383253452:certificate/f32eabfb-6b45-4b3d-856a-70327e1f109b"
+  certificate_arn = aws_acm_certificate_validation.app.certificate_arn
 }

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,0 +1,53 @@
+# Route 53 Hosted Zone for snipethedip.com
+resource "aws_route53_zone" "main" {
+  name = "snipethedip.com"
+
+  tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+# DNS Records for the domain
+resource "aws_route53_record" "api" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "api.snipethedip.com"
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_lb.main.dns_name]
+}
+
+resource "aws_route53_record" "app" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "app.snipethedip.com"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["d3bjg7e6h8jm1k.cloudfront.net"]  # Your CloudFront distribution
+}
+
+resource "aws_route53_record" "www" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "www.snipethedip.com"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["d3bjg7e6h8jm1k.cloudfront.net"]
+}
+
+# Root domain points to load balancer
+resource "aws_route53_record" "root_alias" {
+  zone_id = aws_route53_zone.main.zone_id
+  name    = "snipethedip.com"
+  type    = "A"
+  
+  alias {
+    name                   = aws_lb.main.dns_name
+    zone_id                = aws_lb.main.zone_id
+    evaluate_target_health = true
+  }
+}
+
+# Output the nameservers
+output "nameservers" {
+  description = "Route 53 nameservers - add these to Namecheap"
+  value       = aws_route53_zone.main.name_servers
+}


### PR DESCRIPTION
- Add DNS records for api.snipethedip.com and app.snipethedip.com
- Enable automatic SSL certificate validation via Route 53
- Point root domain to load balancer
- Output nameservers for Namecheap configuration